### PR TITLE
fix: Load even if one or more monitor(s) always fail as long as at least one loads

### DIFF
--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -56,12 +56,10 @@ pub fn sub() -> impl Stream<Item = Message> {
 
                     debug!("start enumerate");
 
-                    let mut some_loaded = false;
                     let mut some_failed = false;
                     for mut display in Display::enumerate() {
                         let brightness = match display.handle.get_vcp_feature(BRIGHTNESS_CODE) {
                             Ok(v) => {
-                                some_loaded = true;
                                 v.value()
                             },
                             // on my machine, i get this error when starting the session
@@ -85,13 +83,11 @@ pub fn sub() -> impl Stream<Item = Message> {
 
                     if some_failed {
                         failed_attempts += 1;
-                    } else {
-                        failed_attempts = 0;
                     }
 
                     // On some monitors this error is permanent
                     // So we mark the app as ready if at least one monitor is loaded after 5 attempts
-                    if (some_failed && failed_attempts < 5) || !some_loaded {
+                    if some_failed && failed_attempts < 5 {
                         state = State::Waiting;
                         continue;
                     }

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -67,8 +67,6 @@ pub fn sub() -> impl Stream<Item = Message> {
                             // on my machine, i get this error when starting the session
                             // can't get_vcp_feature: DDC/CI error: Expected DDC/CI length bit
                             // This go away after the third attempt
-                            // On some monitors this error is permanent
-                            // So we mark the app as read if at least one monitor is loaded above after 5 attempts
                             Err(e) => {
                                 error!("can't get_vcp_feature: {e}");
                                 some_failed = true;
@@ -91,6 +89,8 @@ pub fn sub() -> impl Stream<Item = Message> {
                         failed_attempts = 0;
                     }
 
+                    // On some monitors this error is permanent
+                    // So we mark the app as ready if at least one monitor is loaded after 5 attempts
                     if (some_failed && failed_attempts < 5) || !some_loaded {
                         state = State::Waiting;
                         continue;


### PR DESCRIPTION
Solution is a bit crude but it works.

My laptop monitor always returns an error getting the brightness so the applet never loads any external monitors.