### PR TITLE
added `ChangeGlobalBrightness` event when scrolling

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -118,18 +118,15 @@ impl cosmic::Application for Window {
                 self.send(EventToSub::Set(id, brightness));
             }
             Message::ChangeGlobalBrightness(brightness) => {
-                let updates: Vec<(String, u16)> = self
-                    .monitors
-                    .iter_mut()
-                    .map(|(id, monitor)| {
-                        monitor.brightness =
-                            (monitor.brightness as i16 + brightness).clamp(0, 100) as u16;
-                        (id.clone(), monitor.brightness)
-                    })
-                    .collect();
-
-                for (id, new_brightness) in updates {
-                    self.send(EventToSub::Set(id, new_brightness));
+                let ids: Vec<String> = self.monitors.keys().cloned().collect();
+                for id in ids {
+                    let b = match self.monitors.get_mut(&id) {
+                        Some(monitor) => &mut monitor.brightness,
+                        None => continue,
+                    };
+                    *b = (*b as i16 + brightness).clamp(0, 100) as u16;
+                    let to_send = *b;
+                    self.send(EventToSub::Set(id, to_send));
                 }
             }
             Message::ToggleMinMaxBrightness(id) => {


### PR DESCRIPTION
This will either increase or decrease the brightness of all monitors when scrolling on the applet button in the panel.

This behaves just like the audio applet. Except that I modified the way that `change` is calculated, so that at least on my machine, the change is much more consistent.

original code from `cosmic-applet-audio`:

```
let change = match 
  iced::mouse::ScrollDelta::Lines { x, y } => (x + y) * 5.,
  iced::mouse::ScrollDelta::Pixels { y, .. } => y / 40.3125,
};
```