### PR TITLE
Add monitor label after icon

### DIFF
--- a/src/view.rs
+++ b/src/view.rs
@@ -84,7 +84,7 @@ impl AppState {
 
     fn monitor_view<'a>(&self, id: &'a str, monitor: &'a MonitorState) -> Element<'a, AppMsg> {
         let gamma_map = self.config.get_gamma_map(id);
-
+        println!("{:?}", &monitor.name);
         row()
             .padding(2.0)
             .push(
@@ -135,6 +135,7 @@ impl AppState {
                         row()
                             .spacing(12)
                             .align_y(Alignment::Center)
+                            .push(text(monitor.name.chars().take(12).collect::<String>()))
                             .push(slider(
                                 0..=100,
                                 (monitor.slider_brightness * 100.0) as u16,

--- a/src/view.rs
+++ b/src/view.rs
@@ -84,7 +84,7 @@ impl AppState {
 
     fn monitor_view<'a>(&self, id: &'a str, monitor: &'a MonitorState) -> Element<'a, AppMsg> {
         let gamma_map = self.config.get_gamma_map(id);
-        println!("{:?}", &monitor.name);
+
         row()
             .padding(2.0)
             .push(


### PR DESCRIPTION
Thanks for writing this software, I've found it very useful!

I personally found it inconvenient (and unintuitive) to identify the monitors by looking at the monitor icon tooltip (especially since monitor order currently can change), so I figured I'd add it right before the slider.

This implementation is a simple `.push` addition, but I wonder if it'd be better to wrap the text in some container to keep the size consistent regardless of text length. Thoughts?