### PR TITLE
fix: rescan displays on manual refresh

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -111,7 +111,7 @@ impl AppState {
 
         match kind {
             PopupKind::Popup => {
-                self.send(EventToSub::Refresh);
+                self.send(EventToSub::RefreshBrightness);
 
                 let mut popup_settings = self.core.applet.get_popup_settings(
                     self.core.main_window_id().unwrap(),
@@ -361,7 +361,8 @@ impl cosmic::Application for AppState {
             }
             AppMsg::ConfigChanged(config) => self.config = config,
             AppMsg::Refresh => {
-                self.send(EventToSub::Refresh);
+                // Manual refresh also discovers connected and disconnected displays.
+                self.send(EventToSub::RescanDisplays);
             }
         }
         Task::none()

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -9,7 +9,6 @@ use cosmic::iced::{
     stream,
 };
 use ddc_hi::{Ddc, Display};
-use tokio::sync::watch::Receiver;
 
 use crate::app::AppMsg;
 
@@ -26,23 +25,28 @@ pub struct MonitorInfo {
 
 #[derive(Debug, Clone)]
 pub enum EventToSub {
-    Refresh,
+    /// Refresh brightness values using the cached display handles.
+    RefreshBrightness,
+    /// Re-enumerate connected displays and replace the cached display handles.
+    RescanDisplays,
     Set(DisplayId, ScreenBrightness),
 }
 
 enum State {
     Waiting,
     Fetch,
-    Ready(
-        HashMap<DisplayId, Arc<Mutex<Display>>>,
-        Receiver<EventToSub>,
-    ),
+    Ready(HashMap<DisplayId, Arc<Mutex<Display>>>),
 }
 
 pub fn sub() -> impl Stream<Item = AppMsg> {
     stream::channel(
         100,
         |mut output: cosmic::iced::futures::channel::mpsc::Sender<AppMsg>| async move {
+            // Keep the receiver outside `State` so rescans can leave `Ready` without
+            // disconnecting the sender while enumeration is retried.
+            let (tx, mut rx) = tokio::sync::watch::channel(EventToSub::RefreshBrightness);
+            rx.mark_unchanged();
+
             let mut state = State::Waiting;
             let mut failed_attempts = 0;
 
@@ -99,21 +103,18 @@ pub fn sub() -> impl Stream<Item = AppMsg> {
 
                         debug!("end enumerate");
 
-                        let (tx, mut rx) = tokio::sync::watch::channel(EventToSub::Refresh);
-                        rx.mark_unchanged();
-
                         output
-                            .send(AppMsg::SubscriptionReady((res, tx)))
+                            .send(AppMsg::SubscriptionReady((res, tx.clone())))
                             .await
                             .unwrap();
-                        state = State::Ready(displays, rx);
+                        state = State::Ready(displays);
                     }
-                    State::Ready(displays, rx) => {
+                    State::Ready(displays) => {
                         rx.changed().await.unwrap();
 
                         let last = rx.borrow_and_update().clone();
                         match last {
-                            EventToSub::Refresh => {
+                            EventToSub::RefreshBrightness => {
                                 for (id, display) in displays {
                                     let res = display
                                         .lock()
@@ -134,6 +135,14 @@ pub fn sub() -> impl Stream<Item = AppMsg> {
                                         Err(err) => error!("{:?}", err),
                                     }
                                 }
+                            }
+                            EventToSub::RescanDisplays => {
+                                // The Fetch state performs a full DDC enumeration and sends the
+                                // resulting monitor list back to the application.
+                                // Start each rescan with a fresh retry budget.
+                                failed_attempts = 0;
+                                duration = Duration::from_millis(50);
+                                state = State::Fetch;
                             }
                             EventToSub::Set(id, value) => {
                                 debug_assert!(value <= 100);


### PR DESCRIPTION
## Background

Previously, refreshing only queried brightness values through display handles cached during startup. Because the display list was not enumerated again, newly connected displays were not added and disconnected displays remained visible.

Related issues: #38 , #44 , #59  

## Changes

- Distinguish refreshing brightness values from rescanning connected displays.
- Make the manual Refresh button perform a full DDC display enumeration.
- Update the monitor list when displays are connected or disconnected.
- Keep the monitor command channel alive across enumeration retries.
- Reset the retry state for each manual rescan.

## Manual verification performed on pop!_os 24.04 LTS: 

1. Connect a new display.
2. Click Refresh and verify that the new display appears.
3. Disconnect a display.
4. Click Refresh and verify that the display is removed.

## Potential follow-up work I found during this bug investigation:

- Add event-driven display connect and disconnect detection, so that the manual refresh is no longer needed.
- Right now, each display has a `cosmic-ext-applet-external-monitor-brightness` process instance, consider a shared background service to reduce memory footprint.
<img width="904" height="183" alt="image" src="https://github.com/user-attachments/assets/6e01d1af-7b17-42ec-984f-79bee9a44d81" />

